### PR TITLE
fix: Use 'go vet' instead of 'go tool vet'

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -26,9 +26,9 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
   public function getDefaultBinary() {
     $binary = 'go';
     if (Filesystem::binaryExists($binary)) {
-      // Vet is only accessible through 'go vet' or 'go tool vet'
+      // Vet is only accessible through 'go vet'
       // Let's manually try to find out if it's installed.
-      list($err, $stdout, $stderr) = exec_manual('go tool vet');
+      list($err, $stdout, $stderr) = exec_manual('go vet');
       if ($err === 3) {
         throw new ArcanistMissingLinterException(
           sprintf(
@@ -59,7 +59,7 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
   }
 
   protected function getMandatoryFlags() {
-    return ['tool', 'vet'];
+    return ['vet'];
   }
 
   protected function getDefaultMessageSeverity($code) {


### PR DESCRIPTION
In Go 1.12, `go tool vet` is deprecated in favor of `go vet`, so this breaks when upgrading to Go 1.12. The output looks like:
```
- CommandException: Command failed with error #1!
      COMMAND
      'go' 'tool' 'vet' '/path/to/application.go'

      STDOUT
      (empty)

      STDERR
      vet: invoking "go tool vet" directly is unsupported; use "go vet"
```

Relevant Go 1.12 release note: https://golang.org/doc/go1.12#vet